### PR TITLE
riot.route.exec() deprecated

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -1,7 +1,7 @@
 import './pages/home.tag'
 import './pages/projects.tag'
 
-// we need this to easily check the current route from every component 
+// we need this to easily check the current route from every component
 riot.routeState = {
   view : ''
 };
@@ -12,9 +12,9 @@ class Router{
     this._currentView = null;
     this._views = ['home', 'projects'];
     this._defaultView = 'home';
-    
+
     riot.route(this._handleRoute.bind(this));
-    riot.route.exec(this._handleRoute.bind(this));
+    riot.route.start(true);
   }
 
   _handleRoute(view){
@@ -24,7 +24,7 @@ class Router{
       return riot.route(this._defaultView);
     }
 
-    this._loadView(view); 
+    this._loadView(view);
   }
 
   _loadView(view){


### PR DESCRIPTION
As per [docs](http://riotjs.com/api/route/#riotrouteexec), this is now deprecated. 

`riot.route.start(true)` seems to achieve the same purpose, starting the router and parsing the initial state.
